### PR TITLE
kafka_rest plugin auth token

### DIFF
--- a/plugins/out_kafka_rest/kafka.c
+++ b/plugins/out_kafka_rest/kafka.c
@@ -222,6 +222,7 @@ static void cb_kafka_flush(const void *data, size_t bytes,
     c = flb_http_client(u_conn, FLB_HTTP_POST, ctx->uri,
                         js, js_size, NULL, 0, NULL, 0);
     flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+    flb_http_add_header(c, "Authorization", 13, ctx->token, ctx->token_len);
     flb_http_add_header(c,
                         "Content-Type", 12,
                         "application/vnd.kafka.json.v2+json", 34);

--- a/plugins/out_kafka_rest/kafka.h
+++ b/plugins/out_kafka_rest/kafka.h
@@ -36,6 +36,10 @@ struct flb_kafka_rest {
     char *http_user;
     char *http_passwd;
 
+    /* Auth Token */
+    char *token;
+    int token_len;
+
     /* time key */
     int time_key_len;
     char *time_key;

--- a/plugins/out_kafka_rest/kafka_conf.c
+++ b/plugins/out_kafka_rest/kafka_conf.c
@@ -86,6 +86,16 @@ struct flb_kafka_rest *flb_kr_conf_create(struct flb_output_instance *ins,
         }
     }
 
+    /* Auth Token */
+    tmp = flb_output_get_property("token", ins);
+    if (tmp) {
+        ctx->token = flb_strdup(tmp);
+        ctx->token_len = strlen(tmp);
+    } else {
+        ctx->token = "";
+        ctx->token_len = 0;
+    }
+
     /* Time Key */
     tmp = flb_output_get_property("time_key", ins);
     if (tmp) {
@@ -185,6 +195,9 @@ int flb_kr_conf_destroy(struct flb_kafka_rest *ctx)
     flb_free(ctx->http_user);
     flb_free(ctx->http_passwd);
 
+    flb_free(ctx->token);
+    flb_free(ctx->token_len);
+    
     flb_free(ctx->time_key);
     flb_free(ctx->time_key_format);
 


### PR DESCRIPTION
Support auth token in kafka_rest output plugin.
Accept token as config parameter from .conf file

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
