### PR TITLE
kafka-rest output path parameter

### DIFF
--- a/plugins/out_kafka_rest/kafka.c
+++ b/plugins/out_kafka_rest/kafka.c
@@ -222,7 +222,10 @@ static void cb_kafka_flush(const void *data, size_t bytes,
     c = flb_http_client(u_conn, FLB_HTTP_POST, ctx->uri,
                         js, js_size, NULL, 0, NULL, 0);
     flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
-    flb_http_add_header(c, "Authorization", 13, ctx->token, ctx->token_len);
+    if (ctx->token_len > 0) {
+        flb_http_add_header(c, "Authorization", 13, ctx->token, ctx->token_len);
+    }
+    
     flb_http_add_header(c,
                         "Content-Type", 12,
                         "application/vnd.kafka.json.v2+json", 34);

--- a/plugins/out_kafka_rest/kafka.h
+++ b/plugins/out_kafka_rest/kafka.h
@@ -36,9 +36,12 @@ struct flb_kafka_rest {
     char *http_user;
     char *http_passwd;
 
+    /* Path */
+    char *path;
+
     /* Auth Token */
     char *token;
-    int token_len;
+    size_t token_len;
 
     /* time key */
     int time_key_len;

--- a/plugins/out_kafka_rest/kafka_conf.c
+++ b/plugins/out_kafka_rest/kafka_conf.c
@@ -86,13 +86,21 @@ struct flb_kafka_rest *flb_kr_conf_create(struct flb_output_instance *ins,
         }
     }
 
+    /* Path */
+    tmp = flb_output_get_property("path", ins);
+    if (tmp) {
+        ctx->path = flb_strdup(tmp);
+    } else {
+        ctx->path = flb_strdup("");
+    }
+
     /* Auth Token */
     tmp = flb_output_get_property("token", ins);
     if (tmp) {
         ctx->token = flb_strdup(tmp);
         ctx->token_len = strlen(tmp);
     } else {
-        ctx->token = "";
+        ctx->token = flb_strdup("");
         ctx->token_len = 0;
     }
 
@@ -173,7 +181,11 @@ struct flb_kafka_rest *flb_kr_conf_create(struct flb_output_instance *ins,
     }
 
     /* Set partition based on topic */
-    snprintf(ctx->uri, sizeof(ctx->uri) - 1, "/topics/%s", ctx->topic);
+    if (strlen(ctx->path)) {
+        snprintf(ctx->uri, sizeof(ctx->uri) - 1, "/%s/topics/%s", ctx->path, ctx->topic);
+    } else {
+        snprintf(ctx->uri, sizeof(ctx->uri) - 1, "/topics/%s", ctx->topic);
+    }
 
     /* Kafka: message key */
     tmp = flb_output_get_property("message_key", ins);
@@ -195,8 +207,9 @@ int flb_kr_conf_destroy(struct flb_kafka_rest *ctx)
     flb_free(ctx->http_user);
     flb_free(ctx->http_passwd);
 
+    flb_free(ctx->path);
+    
     flb_free(ctx->token);
-    flb_free(ctx->token_len);
     
     flb_free(ctx->time_key);
     flb_free(ctx->time_key_format);


### PR DESCRIPTION
kafka-rest output plugin to support path as an input parameter from
fluent-bit conf