### PR TITLE
Issue: Adding Kubernetes container logs

### DIFF
--- a/plugins/filter_apm_kubernetes_labels/filter_kubernetes_labels.h
+++ b/plugins/filter_apm_kubernetes_labels/filter_kubernetes_labels.h
@@ -3,14 +3,21 @@
 
 #define SFAPM_PROJECTNAME_LABEL "SFAPM_PROJECTNAME_LABEL"
 #define SFAPM_APPNAME_LABEL "SFAPM_APPNAME_LABEL"
+#define SFAPM_PROJECT_NAME "SFAPM_PROJECT_NAME"
+#define SFAPM_APP_NAME "SFAPM_APP_NAME"
+#define MONITOR_ALL_PODS "MONITOR_ALL_PODS"
 
 #define DEFAULT_PROJECTNAME_LABEL "snappyflow/projectname"
 #define DEFAULT_APPNAME_LABEL "snappyflow/appname"
+#define DEFAULT_PROJECTNAME "project"
+#define DEFAULT_APPNAME "app"
 #define COMPONENT_NAME_LABEL "snappyflow/component"
 #define UA_PARSER_LABEL "snappyflow/ua_parser"
 #define GEO_INFO_LABEL "snappyflow/geo_info"
 #define EXCLUDE_CONTAINER_LABEL "snappyflow/exclude-containers-log"
 #define POD_NAME_IDENT_KEY "pod_name"
+
+#define DEFAULT_MONITOR_PODS_LABEL false
 
 #define POD_NAME_IDENT_KEY_LEN 8
 #define DEFAULT_PROJECTNAME_LABEL_LEN 22
@@ -35,6 +42,9 @@ struct kubernetes_labels_ctx {
     int jsmn_ret;
     char* json_buf;
     char* appname_labe1;
+    char* appname;
     char* projname_labe1;
+    char* projname;
+    bool monitor_pods_label;
     struct flb_filter_instance *ins;
 };

--- a/plugins/filter_apm_kubernetes_labels/filter_kubernetes_labels.h
+++ b/plugins/filter_apm_kubernetes_labels/filter_kubernetes_labels.h
@@ -17,7 +17,7 @@
 #define EXCLUDE_CONTAINER_LABEL "snappyflow/exclude-containers-log"
 #define POD_NAME_IDENT_KEY "pod_name"
 
-#define DEFAULT_MONITOR_PODS_LABEL false
+#define DEFAULT_MONITOR_PODS_LOGS false
 
 #define POD_NAME_IDENT_KEY_LEN 8
 #define DEFAULT_PROJECTNAME_LABEL_LEN 22
@@ -45,6 +45,6 @@ struct kubernetes_labels_ctx {
     char* appname;
     char* projname_labe1;
     char* projname;
-    bool monitor_pods_label;
+    bool monitor_pods_logs;
     struct flb_filter_instance *ins;
 };


### PR DESCRIPTION
Root cause: Enhancement
Changes made:
i) Added flag named monitor_all_pods, if this flag is set then the associated project and app name from config are appended to the log record and pushed to snappyflow 
ii) Added code to extract projectname and appname from env
 iii) Added statements to free up memory
Testcases:
i)When monitor_all_pods flag is set, associated project name and app name is appended to the log record
 ii) When montir_all_pods flag is not set, log record remains as it is with the other fields.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
